### PR TITLE
Modified plugin output & fixes performance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example Usage:
 
 Example Output: (server is online and working)
 
-`OK - Eldewrito Version 0.6.1.0; | players=0;`
+`[UFG] United Federation of Gaming [#1] - Sharp Shooters (0.6.1.0) OK: 0/16 Players | players=0;;;;16`
 
 Example Output: (sever is not responding)
 

--- a/check_eldewrito
+++ b/check_eldewrito
@@ -19,8 +19,8 @@
 # description      :Nagios Plugin for Halo Online (Eldewrito) Servers
 # author           :A Project Under The United Federation of Gaming.
 # contributors     :Kirk
-# date             :12-18-2018
-# version          :0.0.2 Alpha
+# date             :02-27-2019
+# version          :0.0.3 Alpha
 # os               :Linux
 # usage            :check_eldewrito -H $ip $port
 # notes            :If you have any problems, feel free to email us: help [AT] UFG [DOT] gg
@@ -39,9 +39,12 @@ else
 		echo "Usage: check_eldewrito -H 127.0.0.1 11775, replace 127.0.0.1 with your IP for the game server and 11775 with the query port."
 		exit 3
 	else
-		# Query The Game Server
-		players=$(curl -s -qqq http://$2:$3/ | jq -r '.numPlayers')
-		version=$(curl -s -qqq http://$2:$3/ | jq -r '.eldewritoVersion')
+		# Query The Game Server (10 second timeout)
+		data=$(curl -m 10 -s -qqq http://$2:$3/ )
+		players=$(echo $data| jq -r '.numPlayers')
+		maxplayers=$(echo $data | jq -r '.maxPlayers')
+		version=$(echo $data | jq -r '.eldewritoVersion')
+		name=$(echo $data | jq -r '.name')
 	
 		# Validate Response (just make sure values aren't blank)
 		if [[ -z "$players" || -z "$version" ]];
@@ -49,8 +52,9 @@ else
 			echo "Eldewrito CRITICAL: Server did not respond;"
 			exit 2
 		else
-			echo "Eldewrito OK: Version $version; | players=$players;"
+			echo "$name ($version) OK: $players/$maxplayers Players | players=$players;;;;$maxplayers"
 			exit 0
 		fi
 	fi
 fi
+


### PR DESCRIPTION
Hi, 

unfortunately the performance data was broken in Icinga 2, because the performance data format was not fully [nagios compliant](https://nagios-plugins.org/doc/guidelines.html#AEN200).

I also added the server name to the plugin output and set a default timeout in curl, so the script does not run forever. 

I tested this version on icinga2 v2.10.3:
![2019-02-27 20_55_47-icinga web](https://user-images.githubusercontent.com/1371511/53518856-39df7600-3ad2-11e9-8a83-953c5ed50b6e.png)

Unfortunately I don't have a instance of librenms, but if it fully compatible with nagios performance data, it **should** work.